### PR TITLE
Store Objects as CodableConvertible

### DIFF
--- a/Sources/CoreDataCandy/Convertible/CodableConvertible.swift
+++ b/Sources/CoreDataCandy/Convertible/CodableConvertible.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2018-present Amaris Software.
+//
+
+import Foundation
+
+/// A `Codable` object used as the codable model of a `CodableConvertible`
+public protocol CodableConvertibleModel: Codable {
+    associatedtype Convertible: CodableConvertible where Convertible.CodableModel == Self
+
+    var converted: Convertible { get }
+}
+
+/// Can be converted  to a  `CodableConvertibleModel`
+public protocol CodableConvertible {
+    associatedtype CodableModel: CodableConvertibleModel where CodableModel.Convertible == Self
+
+    var codableModel: CodableModel { get }
+}


### PR DESCRIPTION
With the protocols `CodableConvertibleModel` and `CodableConvertible`, it's now possible to use a `NSObject` or another model that is not easily made `Codable` with a custom codable object that will be used to store `NSObject` as data.