### PR TITLE
[#2] Mutliple sort on a DatabaseModel children publisher

### DIFF
--- a/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ChildrenInterfaceProtocol.swift
+++ b/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ChildrenInterfaceProtocol.swift
@@ -13,14 +13,14 @@ public extension DatabaseModel {
         self[keyPath: keyPath].currentValue(on: entity)
     }
 
-    func add<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, in childrenKeyPath: KeyPath<Self, Children>)
+    func add<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, to childrenKeyPath: KeyPath<Self, Children>)
     throws
     where Children.Entity == Entity {
         let childrenInterface = self[keyPath: childrenKeyPath]
         childrenInterface.add(child, on: entity)
     }
 
-    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, in childrenKeyPath: KeyPath<Self, Children>)
+    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, to childrenKeyPath: KeyPath<Self, Children>)
     throws
     where Children.Entity == Entity {
         let childrenInterface = self[keyPath: childrenKeyPath]
@@ -31,11 +31,15 @@ public extension DatabaseModel {
 public extension DatabaseModel where Entity: FetchableEntity {
 
     /// Publisher for the given relationship
-    func publisher<F: FieldPublisher & ChildrenInterfaceProtocol, Criteria>(
+    /// - Parameters:
+    ///   - keyPath: The children to observe
+    ///   - sorts: Sorts to be applied to the emitted array
+    /// - Returns: An array of the children
+    func publisher<F: FieldPublisher & ChildrenInterfaceProtocol>(
         for keyPath: KeyPath<Self, F>,
-        sortedBy sort: Sort<F.ChildModel.Entity, Criteria>)
+        sortedBy sorts: Sort<F.ChildModel.Entity>...)
     -> AnyPublisher<F.Output, Never>
-    where F.Entity == Entity, F.Output == [F.ChildModel] {
-        self[keyPath: keyPath].publisher(for: entity, sortedBy: sort)
+    where F.Entity == Entity, F.Output == [F.ChildModel], F.ChildModel.Entity: FetchableEntity {
+        self[keyPath: keyPath].publisher(for: entity, sortedBy: sorts)
     }
 }

--- a/Sources/CoreDataCandy/Extensions/Publisher+Operators.swift
+++ b/Sources/CoreDataCandy/Extensions/Publisher+Operators.swift
@@ -53,10 +53,16 @@ public extension Publisher {
     }
 }
 
-public extension Publisher where Output: Collection, Output.Element: DatabaseModel, Output.Element.Entity: FetchableEntity {
+extension Publisher where Output: Collection, Output.Element: DatabaseModel, Output.Element.Entity: FetchableEntity {
 
-    func sorted<Value>(with sort: Sort<Output.Element.Entity, Value>) -> AnyPublisher<[Output.Element], Failure> {
-        map { $0.sorted(with: sort) }.eraseToAnyPublisher()
+    /// Sort the children by the first criteria, then by the additional ones
+    func sorted(by sort: Sort<Output.Element.Entity>, _ additionalSorts: Sort<Output.Element.Entity>...) -> AnyPublisher<[Output.Element], Failure> {
+        map { $0.sorted(by: [sort] + additionalSorts) }.eraseToAnyPublisher()
+    }
+
+    /// Sort the children by the first criteria, then by the additional ones
+    func sorted(by sorts: [Sort<Output.Element.Entity>]) -> AnyPublisher<[Output.Element], Failure> {
+        map { $0.sorted(by: sorts) }.eraseToAnyPublisher()
     }
 }
 

--- a/Sources/CoreDataCandy/Fetchable/FetchUpdate/DatabaseModel+FetchUpdate.swift
+++ b/Sources/CoreDataCandy/Fetchable/FetchUpdate/DatabaseModel+FetchUpdate.swift
@@ -7,36 +7,30 @@ import CoreData
 
 extension DatabaseModel where Entity: FetchableEntity {
 
-    static func fetchController(context: NSManagedObjectContext, sorts: [SortDescriptor<Entity>]) -> NSFetchedResultsController<Entity> {
-        let request = Entity.newFetchRequest()
-        request.sortDescriptors = sorts.map(\.descriptor)
-        return NSFetchedResultsController(fetchRequest: request, managedObjectContext: context,
-                                          sectionNameKeyPath: nil, cacheName: nil)
-    }
+    /// Publisher for the entity table updates in Core Data
+    /// - Parameters:
+    ///   - sort: Required sort
+    ///   - additionalSorts: Additional sorts
+    ///   - request: A request to use rather than the default one
+    ///   - context: The context where to fetch
+    /// - Returns: An array of the published models
+    public static func updatePublisher(
+        sortingBy sort: SortDescriptor<Entity>,
+        _ additionalSorts: SortDescriptor<Entity>...,
+        for request: NSFetchRequest<Entity>? = nil,
+        in context: NSManagedObjectContext? = Self.context)
+    -> AnyPublisher<[Self], Never> {
 
-    /// Publisher for the entity table updates in CoreData
-    public static func updatePublisher(sortingBy sort: SortDescriptor<Entity>, in context: NSManagedObjectContext? = Self.context) -> AnyPublisher<[Self], Never> {
         guard let context = context else {
             assertionFailure("No context was provided to fetch the request. " +
                 "Consider passing it as a parameter or changing the default 'nil' value of 'Fetchable.context'")
             return Just([Self]()).eraseToAnyPublisher()
         }
 
-        let fetchController = Self.fetchController(context: context, sorts: [sort])
-
-        return Publishers.fetchUpdate(for: Self.self, fetchController: fetchController)
-            .eraseToAnyPublisher()
-    }
-
-    /// Publisher for the entity table updates in CoreData
-    public static func updatePublisher(sortingBy sorts: [SortDescriptor<Entity>], in context: NSManagedObjectContext? = Self.context) -> AnyPublisher<[Self], Never> {
-        guard let context = context else {
-            assertionFailure("No context was provided to fetch the request. " +
-                             "Consider passing it as a parameter or changing the default 'nil' value of 'Fetchable.context'")
-            return Just([Self]()).eraseToAnyPublisher()
-        }
-
-        let fetchController = Self.fetchController(context: context, sorts: sorts)
+        let request = request ?? Entity.newFetchRequest()
+        let sorts = [sort] + additionalSorts
+        request.sortDescriptors = sorts.map(\.descriptor)
+        let fetchController = NSFetchedResultsController(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
 
         return Publishers.fetchUpdate(for: Self.self, fetchController: fetchController)
             .eraseToAnyPublisher()

--- a/Sources/CoreDataCandy/Fetchable/FetchUpdate/SortDescriptor.swift
+++ b/Sources/CoreDataCandy/Fetchable/FetchUpdate/SortDescriptor.swift
@@ -4,12 +4,14 @@
 
 import Foundation
 
-/// Wrapper around `NSSortDescriptor` to be used with the `FetchUpdate` publisher
+/// Wrapper around `NSSortDescriptor`
 public struct SortDescriptor<Entity: FetchableEntity> {
     public let descriptor: NSSortDescriptor
 }
 
 public extension SortDescriptor {
+
+    // MARK: Ascending
 
     static func ascending<Value: DatabaseFieldValue & Comparable>(_ keyPath: KeyPath<Entity, Value>) -> SortDescriptor {
         SortDescriptor(descriptor: .init(key: keyPath.label, ascending: true))
@@ -19,11 +21,29 @@ public extension SortDescriptor {
         SortDescriptor(descriptor: .init(key: keyPath.label, ascending: true))
     }
 
+    static func ascending<Value: DatabaseFieldValue>(_ keyPath: KeyPath<Entity, Value>, using comparator: @escaping Comparator) -> SortDescriptor {
+        SortDescriptor(descriptor: .init(key: keyPath.label, ascending: true, comparator: comparator))
+    }
+
+    static func ascending<Value: DatabaseFieldValue>(_ keyPath: KeyPath<Entity, Value>, using selector: Selector) -> SortDescriptor {
+        SortDescriptor(descriptor: .init(key: keyPath.label, ascending: true, selector: selector))
+    }
+
+    // MARK: Descending
+
     static func descending<Value: DatabaseFieldValue & Comparable>(_ keyPath: KeyPath<Entity, Value>) -> SortDescriptor {
         SortDescriptor(descriptor: .init(key: keyPath.label, ascending: false))
     }
 
     static func descending<Value: DatabaseFieldValue & Comparable>(_ keyPath: KeyPath<Entity, Value?>) -> SortDescriptor {
         SortDescriptor(descriptor: .init(key: keyPath.label, ascending: false))
+    }
+
+    static func descending<Value: DatabaseFieldValue>(_ keyPath: KeyPath<Entity, Value>, using comparator: @escaping Comparator) -> SortDescriptor {
+        SortDescriptor(descriptor: .init(key: keyPath.label, ascending: false, comparator: comparator))
+    }
+
+    static func descending<Value: DatabaseFieldValue>(_ keyPath: KeyPath<Entity, Value>, using selector: Selector) -> SortDescriptor {
+        SortDescriptor(descriptor: .init(key: keyPath.label, ascending: false, selector: selector))
     }
 }

--- a/Sources/CoreDataCandy/Fetchable/RequestBuilder/RequestBuilder+Steps.swift
+++ b/Sources/CoreDataCandy/Fetchable/RequestBuilder/RequestBuilder+Steps.swift
@@ -128,43 +128,15 @@ public extension RequestBuilder where Step == PredicateStep {
 
 // MARK: Sort
 
-public extension RequestBuilder {
-
-    enum SortDirection {
-        case ascending, descending
-    }
-}
-
 public extension RequestBuilder where Step: SortableStep {
 
-    /// Add a sort descriptor to the request for the given direction and key path
-    func sorted<Value: DatabaseFieldValue & Comparable>(by direction: SortDirection, _ keyPath: KeyPath<Entity, Value>) -> RequestBuilder<Entity, SortStep, Output> {
-        let descriptor = NSSortDescriptor(key: keyPath.label, ascending: direction == .ascending)
-        request.sortDescriptors = [descriptor]
+    /// Add a sort descriptor and additional ones to the request
+    /// ### Examples
+    /// - `.sorted(by: .ascending(\.name))`
+    /// - `.sorted(by: .ascending(\.name), .descending(\.age))`
+    /// - `.sorted(by: .ascending(\.name, using: String.localizedStandardCompare))`
+    func sorted(by sort: SortDescriptor<Entity>, _ additionalSorts: SortDescriptor<Entity>...) -> RequestBuilder<Entity, SortStep, Output> {
+        request.sortDescriptors = ([sort] + additionalSorts).map(\.descriptor)
         return .init(request: request)
-    }
-
-    /// Add a sort descriptor to the request for the given direction and key path
-    func sorted<Value: DatabaseFieldValue & Comparable>(by direction: SortDirection, _ keyPath: KeyPath<Entity, Value?>) -> RequestBuilder<Entity, SortStep, Output> {
-        let descriptor = NSSortDescriptor(key: keyPath.label, ascending: direction == .ascending)
-        request.sortDescriptors = [descriptor]
-        return .init(request: request)
-    }
-}
-
-public extension RequestBuilder where Step == SortStep {
-
-    /// Add an additional sort descriptor to the request for the given direction and key path
-    func then<Value: DatabaseFieldValue & Comparable>(by direction: SortDirection, _ keyPath: KeyPath<Entity, Value>) -> RequestBuilder<Entity, SortStep, Output> {
-        let descriptor = NSSortDescriptor(key: keyPath.label, ascending: direction == .ascending)
-        request.sortDescriptors = (request.sortDescriptors ?? []) + [descriptor]
-        return self
-    }
-
-    /// Add an additional sort descriptor to the request for the given direction and key path
-    func then<Value: DatabaseFieldValue & Comparable>(by direction: SortDirection, _ keyPath: KeyPath<Entity, Value?>) -> RequestBuilder<Entity, SortStep, Output> {
-        let descriptor = NSSortDescriptor(key: keyPath.label, ascending: direction == .ascending)
-        request.sortDescriptors = (request.sortDescriptors ?? []) + [descriptor]
-        return self
     }
 }

--- a/Sources/CoreDataCandy/Fields&Relationships/Relationship/ChildrenInterfaceProtocol.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Relationship/ChildrenInterfaceProtocol.swift
@@ -67,11 +67,11 @@ public extension ChildrenInterfaceProtocol where Entity: NSManagedObject, ChildM
     }
 }
 
-public extension ChildrenInterfaceProtocol where Self: FieldPublisher, Self.Output == [ChildModel], ChildModel.Entity: FetchableEntity {
+extension ChildrenInterfaceProtocol where Self: FieldPublisher, Self.Output == [ChildModel], ChildModel.Entity: FetchableEntity, Entity: NSManagedObject {
 
-    func publisher<Value>(for entity: Entity, sortedBy sort: Sort<ChildModel.Entity, Value>) -> AnyPublisher<Output, Never> {
+    func publisher(for entity: Entity, sortedBy sorts: [Sort<ChildModel.Entity>]) -> AnyPublisher<Output, Never> {
         publisher(for: entity)
-            .sorted(with: sort)
+            .sorted(by: sorts)
             .eraseToAnyPublisher()
     }
 }

--- a/Tests/CoreDataCandyTests/DatabaseModelTests.swift
+++ b/Tests/CoreDataCandyTests/DatabaseModelTests.swift
@@ -91,6 +91,7 @@ extension DatabaseModelTests {
             NSFetchRequest<StubEntity>(entityName: "Stub")
         }
 
+        @objc var children: NSSet?
         @objc var flag = false
         @objc var property: String? = ""
     }
@@ -99,6 +100,7 @@ extension DatabaseModelTests {
 
         let _entityWrapper = EntityWrapper(entity: StubEntity())
 
+        let children = Children(\.children, as: StubModel.self)
         let property = Field(\.property, validations: .doesNotContain("Yo"))
         let flag = Field(\.flag)
 

--- a/Tests/CoreDataCandyTests/SortTests.swift
+++ b/Tests/CoreDataCandyTests/SortTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright © 2018-present Amaris Software.
+//
+
+import XCTest
+@testable import CoreDataCandy
+
+final class SortTests: XCTestCase {
+
+    let riri = StubStruct(name: "Riri", score: 20)
+    let fifi = StubStruct(name: "Fifi", score: 10)
+    let loulou = StubStruct(name: "Loulou", score: 40)
+    let donald = StubStruct(name: "Donald", score: 20)
+
+    var stubs1: [StubStruct] { [riri, fifi, loulou] }
+    var stubs2: [StubStruct] { stubs1 + [donald] }
+
+    func testAscending() {
+        XCTAssertEqual(stubs1.sorted(by: .ascending(\.name)), [fifi, loulou, riri])
+    }
+
+    func testDescending() {
+        XCTAssertEqual(stubs1.sorted(by: .descending(\.score)), [loulou, riri, fifi])
+    }
+
+    func testTwoSorts() {
+        XCTAssertEqual(stubs2.sorted(by: .descending(\.score), .ascending(\.name)), [loulou, donald, riri, fifi])
+    }
+}
+
+extension SortTests {
+
+    struct StubStruct: Equatable {
+        var name: String
+        var score: Double
+    }
+}


### PR DESCRIPTION
- It’s, now possible to specify several sorts to use when calling the children publisher of a DatabaseModel
- Changed the sort specifications on a request building process for something more coherent with the rest of the library
- Also updated the Readme

Closes #2 