### PR TITLE
Made `Validation.init` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. `CoreDataCandy` adheres to [Semantic Versioning](http://semver.org).
 
 ---
+## [0.2.1](https://github.com/amaris/core-data-candy/tree/0.2.1) (23/11/2020)
+
+### Fixed
+- `Validation.init` now public
+
 ## [0.2.0](https://github.com/amaris/core-data-candy/tree/0.2.0) (20/11/2020)
 
 ### Added

--- a/Sources/CoreDataCandy/Validation/Validation.swift
+++ b/Sources/CoreDataCandy/Validation/Validation.swift
@@ -6,4 +6,8 @@
 /// Specified in a `FieldWrapper` initialisation to validate the received value
 public struct Validation<Value> {
     public var validate: (Value) throws -> Void
+
+    public init(_ validate: @escaping (Value) throws -> Void) {
+        self.validate = validate
+    }
 }


### PR DESCRIPTION
### Fixed
- `Validation.init` now public