### PR TITLE
Changed store precondition failures for emitted errors

### DIFF
--- a/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ParentInterfaceProtocol.swift
+++ b/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ParentInterfaceProtocol.swift
@@ -20,4 +20,16 @@ public extension DatabaseModel {
     where P.Entity == Entity, F.Entity == P.ParentModel.Entity, F.Value: ExpressibleByNilLiteral {
         self[keyPath: parentKeyPath].current(valueKeyPath, on: entity)
     }
+
+    /// Get the current parent of the model
+    func parent<P: ParentInterfaceProtocol>(_ keyPath: KeyPath<Self, P>)
+    -> P.ParentModel?
+    where P.Entity == Entity {
+
+        let parentKeyPath = self[keyPath: keyPath].keyPath
+        guard let parentEntity = entity[keyPath: parentKeyPath] else {
+            return nil
+        }
+        return P.ParentModel(entity: parentEntity)
+    }
 }

--- a/Sources/CoreDataCandy/Fields&Relationships/Field/ConversionError.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Field/ConversionError.swift
@@ -1,0 +1,40 @@
+//
+// CoreDataCandy
+// Copyright © 2018-present Amaris Software.
+// MIT license, see LICENSE file for details
+
+import Foundation
+import Combine
+import CoreData
+
+/// A field interface that emits conversion errors
+protocol ConversionErrorObservable {
+
+    var errorSubject: PassthroughSubject<ConversionError, Never> { get }
+}
+
+/// Emitted through a publisher when a conversion from stored <-> output value failed
+public struct ConversionError: LocalizedError {
+
+    /// The entity attribute label
+    public var attributeLabel: String
+    public var errorDescription: String?
+
+    public init(attributeLabel: String, description: String) {
+        self.attributeLabel = attributeLabel
+        errorDescription = description
+    }
+}
+
+public extension ConversionError {
+
+    static func decodingError<E: NSManagedObject, Value>(keyPath: KeyPath<E, Value>, description: String) -> ConversionError {
+        ConversionError(attributeLabel: keyPath.label,
+                        description: "Decoding error. \(description)")
+    }
+
+    static func rawRepresentable<E: NSManagedObject, Value>(keyPath: KeyPath<E, Value>, description: String) -> ConversionError {
+        ConversionError(attributeLabel: keyPath.label,
+                        description: "Raw representable init error. \(description)")
+    }
+}

--- a/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterface.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterface.swift
@@ -4,14 +4,15 @@
 // MIT license, see LICENSE file for details
 
 import CoreData
+import Combine
 
 /// Holds a CoreData field/attribute with custom validation and conversion logic
-public struct FieldInterface<FieldValue: DatabaseFieldValue, Value, Entity: DatabaseEntity> {
+public struct FieldInterface<FieldValue: DatabaseFieldValue, Value, Entity: DatabaseEntity>: ConversionErrorObservable {
 
     // MARK: - Constants
 
     public typealias OutputConversion = (FieldValue) -> Value
-    public typealias StoreConversion = (Value) -> FieldValue
+    public typealias StoreConversion = (Value) -> FieldValue?
 
     // MARK: - Properties
 
@@ -19,6 +20,9 @@ public struct FieldInterface<FieldValue: DatabaseFieldValue, Value, Entity: Data
     public let outputConversion: OutputConversion
     public let storeConversion: StoreConversion
     public let validation: Validation<Value>
+
+    let errorSubject = PassthroughSubject<ConversionError, Never>()
+    public var conversionErrorPublisher: AnyPublisher<ConversionError, Never> { errorSubject.eraseToAnyPublisher() }
 
     // MARK: - Initialisation
 


### PR DESCRIPTION
Also added a way to access a model’s parent model.

If an error occurs while converting a data or raw representable type from the stored value, it's now possible to specify a fallback value that should be used. If no fallback is provided, a precondition failure is used.
Also, to let the possibility to know what happened, the fields now offer a conversion errors publisher with relevant informations. The model that owns them can then subscribe to the publishers it wants to know about conversion errors.
Those publishers will emit if the conversion `store -> output` or `output -> stored` encounters an error.

Closes #23
Closes #22 