### PR TITLE
[#32] Assign nil to an optional field

### DIFF
--- a/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ChildrenInterfaceProtocol.swift
+++ b/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+ChildrenInterfaceProtocol.swift
@@ -20,7 +20,7 @@ public extension DatabaseModel {
         childrenInterface.add(child, on: entity)
     }
 
-    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, to childrenKeyPath: KeyPath<Self, Children>)
+    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, from childrenKeyPath: KeyPath<Self, Children>)
     where Children.Entity == Entity {
         let childrenInterface = self[keyPath: childrenKeyPath]
         childrenInterface.remove(child, on: entity)
@@ -33,7 +33,7 @@ public extension DatabaseModel {
         childrenInterface.insert(child, at: index, on: entity)
     }
 
-    func remove<ChildModel: DatabaseModel>(at index: Int, in childrenKeyPath: KeyPath<Self, OrderedChildren<ChildModel>>) throws {
+    func remove<ChildModel: DatabaseModel>(at index: Int, from childrenKeyPath: KeyPath<Self, OrderedChildren<ChildModel>>) throws {
         let childrenInterface = self[keyPath: childrenKeyPath]
         childrenInterface.remove(at: index, on: entity)
     }

--- a/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+FetchUpdate.swift
+++ b/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel+FetchUpdate.swift
@@ -7,7 +7,7 @@ import Combine
 import CoreData
 
 extension DatabaseModel {
-    
+
     public static func updatePublisher(
         sortingBy sort: SortDescriptor<Entity>,
         _ additionalSorts: SortDescriptor<Entity>...,

--- a/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel.swift
+++ b/Sources/CoreDataCandy/Database/DatabaseModel/DatabaseModel.swift
@@ -75,14 +75,14 @@ public protocol DatabaseModel: Fetchable, Hashable, CustomDebugStringConvertible
     where Children.Entity == Entity
 
     /// Remove a child from the one-ton-many relationship
-    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, to childrenKeyPath: KeyPath<Self, Children>)
+    func remove<Children: ChildrenInterfaceProtocol>(_ child: Children.ChildModel, from childrenKeyPath: KeyPath<Self, Children>)
     where Children.Entity == Entity
 
     /// Insert a child at the specified index to the ordered one-ton-many relationship
     func insert<ChildModel: DatabaseModel>(_ child: ChildModel, at index: Int, in childrenKeyPath: KeyPath<Self, OrderedChildren<ChildModel>>) throws
 
     /// Remove a child  at the specified index to the ordered one-ton-many relationship
-    func remove<ChildModel: DatabaseModel>(at index: Int, in childrenKeyPath: KeyPath<Self, OrderedChildren<ChildModel>>) throws
+    func remove<ChildModel: DatabaseModel>(at index: Int, from childrenKeyPath: KeyPath<Self, OrderedChildren<ChildModel>>) throws
 
     /// Publisher for the given relationship
     /// - Parameters:

--- a/Sources/CoreDataCandy/Extensions/Subscribers+Extensions.swift
+++ b/Sources/CoreDataCandy/Extensions/Subscribers+Extensions.swift
@@ -104,4 +104,3 @@ extension Subscribers {
         }
     }
 }
-

--- a/Sources/CoreDataCandy/Fetchable/Predicate/PredicateRightValue.swift
+++ b/Sources/CoreDataCandy/Fetchable/Predicate/PredicateRightValue.swift
@@ -8,7 +8,7 @@ import CoreData
 /// An operator and its right operand for a predicate, with no key path.
 public struct PredicateRightValue<Entity: NSManagedObject, Value: DatabaseFieldValue, TestValue> {
     public typealias PredicateExpression = (KeyPath<Entity, Value>) -> Predicate<Entity, Value, TestValue>
-    
+
     public let predicate: PredicateExpression
 
     public init(predicate: @escaping PredicateExpression) {

--- a/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterface.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterface.swift
@@ -12,7 +12,7 @@ public struct FieldInterface<FieldValue: DatabaseFieldValue, Value, Entity: Data
     // MARK: - Constants
 
     public typealias OutputConversion = (FieldValue) -> Value
-    public typealias StoreConversion = (Value) -> FieldValue?
+    public typealias StoreConversion = (Value) -> FieldValue
 
     // MARK: - Properties
 

--- a/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterfaceProtocol.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Field/FieldInterfaceProtocol.swift
@@ -13,7 +13,7 @@ public protocol FieldInterfaceProtocol: FieldPublisher, FieldModifier {
 
     associatedtype FieldValue: DatabaseFieldValue
     typealias OutputConversion = (FieldValue) -> Value
-    typealias StoreConversion = (Value) -> FieldValue?
+    typealias StoreConversion = (Value) -> FieldValue
 
     // MARK: - Properties
 
@@ -72,9 +72,7 @@ public extension FieldInterfaceProtocol where Entity: NSManagedObject {
 public extension FieldInterfaceProtocol {
 
     func set(_ value: Value, on entity: Entity) {
-        if let stored = storeConversion(value) {
-            entity[keyPath: keyPath] = stored
-        }
+        entity[keyPath: keyPath] = storeConversion(value)
     }
 
     func validate(_ value: Value) throws {

--- a/Sources/CoreDataCandy/Fields&Relationships/Field/UniqueFieldInterface.swift
+++ b/Sources/CoreDataCandy/Fields&Relationships/Field/UniqueFieldInterface.swift
@@ -12,7 +12,7 @@ public struct UniqueFieldInterface<FieldValue: DatabaseFieldValue & Equatable, V
     // MARK: - Constants
 
     public typealias OutputConversion = (FieldValue) -> Value
-    public typealias StoreConversion = (Value) -> FieldValue?
+    public typealias StoreConversion = (Value) -> FieldValue
 
     // MARK: - Properties
 
@@ -52,9 +52,7 @@ public struct UniqueFieldInterface<FieldValue: DatabaseFieldValue & Equatable, V
     /// Returns the given value as a stored `FieldValue` while ensuring its unicity
     @discardableResult
     func uniqueStoredValue(for value: Value, in context: NSManagedObjectContext) throws -> FieldValue {
-        guard let storedValue = storeConversion(value) else {
-            throw ConversionError(attributeLabel: keyPath.label, description: "Internal error while converting stored value \(value) to \(Value.self)")
-        }
+        let storedValue = storeConversion(value)
 
         if try Entity.request().first().where(keyPath == storedValue).fetch(in: context) != nil {
             let field = keyPath.label.components(separatedBy: ".").last ?? ""

--- a/Tests/CoreDataCandyTests/DatabaseModelTests.swift
+++ b/Tests/CoreDataCandyTests/DatabaseModelTests.swift
@@ -82,6 +82,16 @@ final class DatabaseModelTests: XCTestCase {
             .toggle(\.flag, on: model)
             .store(in: &subscriptions)
     }
+
+    func testAssignNil() throws {
+        let model = StubModel()
+
+        model.assign("toto", to: \.property)
+        XCTAssertEqual(model.current(\.property), "toto")
+
+        model.assign(nil, to: \.property)
+        XCTAssertNil(model.current(\.property))
+    }
 }
 
 extension DatabaseModelTests {


### PR DESCRIPTION
Closes #32 

Allow a `nil` value to be assign on a model field.

Also change the function remove children "to" parameter name to "from".